### PR TITLE
Use 32-bit port for Teensy 4.0/4.1

### DIFF
--- a/DmxSimple.cpp
+++ b/DmxSimple.cpp
@@ -19,7 +19,13 @@ static uint16_t dmxMax = 16; /* Default to sending the first 16 channels */
 static uint8_t dmxStarted = 0;
 static uint16_t dmxState = 0;
 
+#if defined(ARDUINO_TEENSY40) || defined(ARDUINO_TEENSY41)
+// Teensy 4.X has 32-bit ports
+static volatile uint32_t *dmxPort;
+#else
 static volatile uint8_t *dmxPort;
+#endif
+
 static uint8_t dmxBit = 0;
 static uint8_t dmxPin = 3; // Defaults to output on pin 3 to support Tinker.it! DMX shield
 


### PR DESCRIPTION
This fixes using FastLED with Teensy 4.0/4.1 in PlatformIO.

Without this, I get the following error when trying to build a Teensy 4.0 project that has `#include <FastLED.h>`:

```
/home/adam/.platformio/packages/framework-arduinoteensy/libraries/DmxSimple/DmxSimple.cpp: In function 'void dmxBegin()':
/home/adam/.platformio/packages/framework-arduinoteensy/libraries/DmxSimple/DmxSimple.cpp:82:11: error: cannot convert 'volatile uint32_t* {aka volatile long unsigned int*}' to 'volatile uint8_t* {aka volatile unsigned char*}' in assignment
   dmxPort = portOutputRegister(digitalPinToPort(dmxPin));
           ^
```

I don't have the hardware to test this, but it does fix compiling.