### PR TITLE
Added ability to change DMX start code and lengthened SPACE for BREAK

### DIFF
--- a/DmxSimple.cpp
+++ b/DmxSimple.cpp
@@ -21,7 +21,13 @@ static uint16_t dmxState = 0;
 
 static uint8_t startCode = 0; // First byte sent in the frame
 
+#if defined(ARDUINO_TEENSY40) || defined(ARDUINO_TEENSY41) || defined(ARDUINO_TEENSY_MICROMOD)
+// Tensy 4.X has 32-bit ports
+static volatile uint32_t *dmxPort;
+#else
 static volatile uint8_t *dmxPort;
+#endif
+
 static uint8_t dmxBit = 0;
 static uint8_t dmxPin = 3; // Defaults to output on pin 3 to support Tinker.it! DMX shield
 

--- a/DmxSimple.h
+++ b/DmxSimple.h
@@ -21,6 +21,7 @@ class DmxSimpleClass
     void maxChannel(int);
     void write(int, uint8_t);
     void usePin(uint8_t);
+    void setStartCode(uint8_t);
 };
 extern DmxSimpleClass DmxSimple;
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Set the number of DMX channels in the DMX system. The DMX system sends out chann
 
 Set the output pin. DmxSimple defaults to using pin 3, making it compatible with the Tinker.it! DMX shield. But if you use this function, you can output on any pin capable of digital output. 
 
+### DmxSimple.setStartCode(value);
+
+#### (EXPERIMENTAL)
+
+Set the first byte in the DMX data frame. The first byte is the start code, signalling the type of data contained in the frame. A start code of 0x00 corresponds to standard DMX dimmer values. Other start codes may indicate configuration data for a fixture or manufacturer-specific signals. This defaults to 0 and is rarely set to anything different. This is included more for completeness than full functionality. You would typically send an entirely different frame when using a non-zero start code, but the current implementation does not allow for altering the entire frame while output is disabled.
+
 ## DmxSimple community
 
 We now have a group on Google Groups. Get assistance starting with DMX, or show off your installations. 

--- a/examples/SerialToDmx/SerialToDmx.ino
+++ b/examples/SerialToDmx/SerialToDmx.ino
@@ -5,9 +5,11 @@
 **
 ** <number>c : Select DMX channel
 ** <number>v : Set DMX channel to new value
+** <number>s : Set DMX start code
 **
 ** These can be combined. For example:
 ** 100c355w : Set channel 100 to value 255.
+** 34s23c244w : Set start code to 34, and channel 23 to 244.
 **
 ** For more details, and compatible Processing sketch,
 ** visit http://code.google.com/p/tinkerit/wiki/SerialToDmx
@@ -23,6 +25,7 @@ void setup() {
   Serial.println("Syntax:");
   Serial.println(" 123c : use DMX channel 123");
   Serial.println(" 45w  : set current channel to value 45");
+  Serial.println(" 10s  : set start code to value 10");
 }
 
 int value = 0;
@@ -35,6 +38,8 @@ void loop() {
   c = Serial.read();
   if ((c>='0') && (c<='9')) {
     value = 10*value + c - '0';
+  } else if (c =='s') {
+    DmxSimple.setStartCode(value);
   } else {
     if (c=='c') channel = value;
     else if (c=='w') {

--- a/keywords.txt
+++ b/keywords.txt
@@ -15,6 +15,7 @@ DmxSimple	KEYWORD1
 write	KEYWORD2
 maxChannel	KEYWORD2
 usePin	KEYWORD2
+setStartCode	KEYWORD2
   
 #######################################
 # Constants (LITERAL1)

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=DmxSimple
-version=3.1
+version=3.2
 author=Peter Knight, Tinker.it!
 maintainer=Paul Stoffregen
 sentence=Drive DMX controlled lights and visual effects available from DJ or theatrical suppliers.

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,3 +1,8 @@
+DmxSimple v3.2 patch:
+  Changes from v3.1 to v3.2:
+    Added the ability to set the start code of the DMX frame
+    Lengthened the reset pulse "SPACE" for BREAK to be within DMX512-A spec
+      (ANSI E1.11-2008 (R2018)), minimum 92 microseconds
 DmxSimple v3 release:
   Changes from v2 to v3:
     Optimised interrupt routine now supports serial baud rates up to 115200.


### PR DESCRIPTION
I was developing a DMX decoder on an FPGA, and was using DmxSimple to test it. I noticed that the reset pulse (SPACE for BREAK) was shorter than the minimum (92us) specified in the DMX512-A spec (ANSI E1.11-2008 (R2018)), so I lengthened it from 80us to 100us.

I also added an experimental feature to set the start code of the DMX frame. I say experimental because the features necessary to make this change useful outside of experimentation are lacking. Each start code should have its own buffer (which could be dynamically allocated) to prevent sending unintended data with any given start code, which would happen in the current implementation. I added this feature to test my decoder's rejection of frames with a non-zero start code.